### PR TITLE
Unique hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ fmt:
 clean:
 	rm -f warp
 	go clean -r
+
+test:
+	godep go test

--- a/image.go
+++ b/image.go
@@ -80,10 +80,6 @@ func getImagePath(hash string, width int) (string, error) {
 		return "", err
 	}
 
-	if filepath.Ext(path) == ".gif" {
-		return "", fmt.Errorf("resizing gifs are not supported")
-	}
-
 	if width <= 0 || width >= actualWidth {
 		return config.absolutePath(path), nil
 	}
@@ -94,6 +90,10 @@ func getImagePath(hash string, width int) (string, error) {
 // Resize the image if neccessary and save it. Returns the new path of the
 // resized image.
 func resizeImage(path string, width int) (string, error) {
+	if filepath.Ext(path) == ".gif" {
+		return "", fmt.Errorf("resizing gifs are not supported")
+	}
+
 	dir := filepath.Dir(path)
 	filename := fmt.Sprintf("%d_%s", width, filepath.Base(path))
 	newpath := filepath.Join(dir, filename)

--- a/image_test.go
+++ b/image_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestCannotResizeGifImages(t *testing.T) {
+	_, err := resizeImage("grumpy-cat.gif", 500)
+
+	if err == nil || err.Error() != "resizing gifs are not supported" {
+		t.Error("resizing gifs should throw an error")
+	}
+}

--- a/scripts/sql/schema.sql
+++ b/scripts/sql/schema.sql
@@ -6,7 +6,7 @@ CREATE TABLE images (
     filepath        varchar,
     height          integer,
     width           integer,
-    hash            varchar,
+    hash            varchar UNIQUE,
     created_at      timestamp,
     PRIMARY KEY(id)
 );


### PR DESCRIPTION
Added unique constraint for image hashes and updated error reporting for the users.

Fixed gif serving: gifs cannot be resized, only the original size can be served. 

Not resizing gifs is not a really good solution. We should look into resizing (animated) gifs and how it effects them.
