### PR TITLE
HTTP basic authentication

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+)
+
+func basicAuth(realm string, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		failed := false
+		auth := r.Header.Get("Authorization")
+		if auth != "" {
+			digest := strings.TrimPrefix(auth, "Basic ")
+			decoded, err := base64.StdEncoding.DecodeString(digest)
+
+			if err != nil {
+				log.Printf("Error decoding basic auth header: %s", err)
+
+			} else {
+				parts := strings.SplitN(string(decoded), ":", 2)
+
+				if parts[0] == config.User && parts[1] == config.Password {
+					log.Printf("Successful authentication from %s", r.RemoteAddr)
+					h.ServeHTTP(w, r)
+					return
+				}
+			}
+			failed = true
+		}
+
+		if failed {
+			log.Printf("Failed authentication from %s", r.RemoteAddr)
+		}
+
+		w.Header().Add("WWW-Authenticate", fmt.Sprintf("Basic realm=\"%s\"", realm))
+		http.Error(w, "Not Authorized", http.StatusUnauthorized)
+	})
+}

--- a/config.go
+++ b/config.go
@@ -18,6 +18,8 @@ type dbConfiguration struct {
 type configuration struct {
 	UploadPath    string
 	ServerAddress string
+	User          string
+	Password      string
 	Db            dbConfiguration
 }
 
@@ -34,6 +36,10 @@ func loadConfiguration(configPath string) configuration {
 	var config configuration
 	if err = json.Unmarshal(data, &config); err != nil {
 		log.Fatal(err)
+	}
+
+	if config.User == "" || config.Password == "" {
+		log.Fatal("user and password are required in the config")
 	}
 
 	return config

--- a/config/config.json.dist
+++ b/config/config.json.dist
@@ -1,10 +1,12 @@
 {
     "uploadPath": "/base/path/to/upload/images",
     "serverAddress": "example.com",
+    "user": "admin",
+    "password": "",
     "db": {
         "name": "warp",
         "user": "warp",
-        "pass": "almafa",
+        "pass": "<pass>",
         "port": 5432,
         "pool": 5
     }

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/lib/pq"
 	"log"
 	"net/http"
+	"os"
 )
 
 var (
@@ -23,11 +24,21 @@ func main() {
 	env0 := flag.String("env", "dev", "possible values: dev, prod, test")
 	configPath := flag.String("config", "config/config.json", "path of the confile file")
 	port := flag.String("port", ":8080", "port to run on")
+	logfile := flag.String("log", "", "path to the logfile; if left empty the app will log to stdout")
 	flag.Parse()
 
+	setLogOutput(*logfile)
 	env = environment(*env0)
 	config = loadConfiguration(*configPath)
 
+	initDb()
+	createPreparedStmts()
+
+	log.Printf("Started on %s port in %s mode", *port, env)
+	http.ListenAndServe(*port, nil)
+}
+
+func initDb() {
 	var err error
 	db, err = sql.Open("postgres", fmt.Sprintf("dbname=%s port=%d user=%s password=%s", config.Db.Name, config.Db.Port, config.Db.User, config.Db.Pass))
 	db.SetMaxIdleConns(config.Db.Pool)
@@ -35,6 +46,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func createPreparedStmts() {
+	var err error
 
 	imageInsertStmt, err = db.Prepare(ImageInsertSql)
 	if err != nil {
@@ -55,7 +70,15 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
 
-	log.Printf("Started on %s port", *port)
-	http.ListenAndServe(*port, nil)
+func setLogOutput(logfile string) {
+	if logfile != "" {
+		file, err := os.OpenFile(logfile, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+		if err != nil {
+			panic("cannot open file for logging")
+		}
+		log.SetOutput(file)
+	}
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 }

--- a/web.go
+++ b/web.go
@@ -25,6 +25,7 @@ var (
 
 const (
 	SearchImageByTitleStmt = "SELECT title, orig_filename, height, width, hash FROM images WHERE LOWER(title) LIKE $1"
+	WarpRealm              = "warp"
 )
 
 func init() {
@@ -32,8 +33,8 @@ func init() {
 
 	// register routes
 	mux.Get("/", http.HandlerFunc(root))
-	mux.Get("/upload", http.HandlerFunc(uploadPage))
-	mux.Post("/upload", http.HandlerFunc(uploadHandler))
+	mux.Get("/upload", basicAuth(WarpRealm, http.HandlerFunc(uploadPage)))
+	mux.Post("/upload", basicAuth(WarpRealm, http.HandlerFunc(uploadHandler)))
 
 	mux.Get("/search", http.HandlerFunc(searchPage))
 	mux.Get("/image/:hash", http.HandlerFunc(imagePage))


### PR DESCRIPTION
Added a simple implementation of HTTP basic authentication.
- user and password are set in the config.json file
- only one credential is available, everybody has to use that
- basic auth is set on /upload route
